### PR TITLE
Add jQuery dependency to Javascript loading

### DIFF
--- a/classes/WPML/Front.php
+++ b/classes/WPML/Front.php
@@ -71,7 +71,7 @@ class WPML_Front
             // set js file
             if ($this->optionValues['protect']) {
                 wp_enqueue_script('wp-mailto-links',
-                    WPML::url('js/wp-mailto-links.js'), array(),
+                    WPML::url('js/wp-mailto-links.js'), array('jquery'),
                     WPML::get('version'));
             }
 


### PR DESCRIPTION
The Javascript to make the links was loading before jQuery, which was causing issues when a page was first loaded. I have added the dependency such that it loads after jQuery.